### PR TITLE
deps: updates wazero to 1.0.0-pre.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/mathetake/wazero-re2
 
 go 1.19
 
-require github.com/tetratelabs/wazero v1.0.0-pre.1.0.20220908045204-b0140b4964d5
+require github.com/tetratelabs/wazero v1.0.0-pre.3

--- a/lib.go
+++ b/lib.go
@@ -35,8 +35,8 @@ type re2Instance struct {
 
 func newRe2(ctx context.Context, r wazero.Runtime) *re2Instance {
 	// Stubbed main function to be used as a library (WASI reactor).
-	if _, err := r.NewModuleBuilder("env").
-		ExportFunction("__main_argc_argv", func(int32, int32) int32 { return 0 }).
+	if _, err := r.NewHostModuleBuilder("env").
+		NewFunctionBuilder().WithFunc(func(int32, int32) int32 { return 0 }).Export("__main_argc_argv").
 		Instantiate(ctx, r); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.3](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.3). This is the last release that will build with Go 1.17.

Notably, this improves performance and changes host function syntax.
